### PR TITLE
Development

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### 1.1.4
+### 1.1.5
 * FEAT: Enable fine-tuning of retention times for predictions.
 * FEAT: Add the predicted retention time and ion mobility values to the "Main tab" of the dashboard.
 * FIX: Correct the mass calculation for modified peptides in prediction mode.

--- a/alphaviz/__init__.py
+++ b/alphaviz/__init__.py
@@ -1,7 +1,7 @@
 #!python
 
 __project__ = "alphaviz"
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 __license__ = "Apache"
 __description__ = "A interactive Dashboard to explore mass spectrometry data."
 __author__ = "Eugenia Voytik"

--- a/misc/bumpversion.cfg
+++ b/misc/bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.4
+current_version = 1.1.5
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/release/one_click_linux_gui/control
+++ b/release/one_click_linux_gui/control
@@ -1,5 +1,5 @@
 Package: alphaviz
-Version: 1.1.4
+Version: 1.1.5
 Architecture: all
 Maintainer: Mann Labs <opensource@alphapept.com>
 Description: alphaviz

--- a/release/one_click_linux_gui/create_installer_linux.sh
+++ b/release/one_click_linux_gui/create_installer_linux.sh
@@ -17,7 +17,7 @@ python setup.py sdist bdist_wheel
 # Setting up the local package
 cd release/one_click_linux_gui
 # Make sure you include the required extra packages and always use the stable or very-stable options!
-pip install "../../dist/alphaviz-1.1.4-py3-none-any.whl[stable,gui-stable]"
+pip install "../../dist/alphaviz-1.1.5-py3-none-any.whl[stable,gui-stable]"
 
 # Creating the stand-alone pyinstaller folder
 pip install pyinstaller==4.2

--- a/release/one_click_macos_gui/Info.plist
+++ b/release/one_click_macos_gui/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIconFile</key>
 	<string>alpha_logo.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>alphaviz.1.1.4</string>
+	<string>alphaviz.1.1.5</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.4</string>
+	<string>1.1.5</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/release/one_click_macos_gui/create_installer_macos.sh
+++ b/release/one_click_macos_gui/create_installer_macos.sh
@@ -20,7 +20,7 @@ python setup.py sdist bdist_wheel
 
 # Setting up the local package
 cd release/one_click_macos_gui
-pip install "../../dist/alphaviz-1.1.4-py3-none-any.whl[stable,gui-stable]"
+pip install "../../dist/alphaviz-1.1.5-py3-none-any.whl[stable,gui-stable]"
 
 # Creating the stand-alone pyinstaller folder
 pip install pyinstaller==4.2
@@ -40,5 +40,5 @@ cp ../../LICENSE.txt Resources/LICENSE.txt
 cp ../logos/alpha_logo.png Resources/alpha_logo.png
 chmod 777 scripts/*
 
-pkgbuild --root dist/alphaviz --identifier de.mpg.biochem.alphaviz.app --version 1.1.4 --install-location /Applications/alphaviz.app --scripts scripts alphaviz.pkg
+pkgbuild --root dist/alphaviz --identifier de.mpg.biochem.alphaviz.app --version 1.1.5 --install-location /Applications/alphaviz.app --scripts scripts alphaviz.pkg
 productbuild --distribution distribution.xml --resources Resources --package-path alphaviz.pkg dist/alphaviz_gui_installer_macos.pkg

--- a/release/one_click_macos_gui/distribution.xml
+++ b/release/one_click_macos_gui/distribution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <installer-script minSpecVersion="1.000000">
-    <title>alphaviz 1.1.4</title>
+    <title>alphaviz 1.1.5</title>
     <background mime-type="image/png" file="alpha_logo.png" scaling="proportional"/>
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />

--- a/release/one_click_windows_gui/alphaviz_innoinstaller.iss
+++ b/release/one_click_windows_gui/alphaviz_innoinstaller.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "alphaviz"
-#define MyAppVersion "1.1.4"
+#define MyAppVersion "1.1.5"
 #define MyAppPublisher "Max Planck Institute of Biochemistry and the University of Copenhagen, Mann Labs"
 #define MyAppURL "https://github.com/MannLabs/alphaviz"
 #define MyAppExeName "alphaviz_gui.exe"

--- a/release/one_click_windows_gui/create_installer_windows.sh
+++ b/release/one_click_windows_gui/create_installer_windows.sh
@@ -17,7 +17,7 @@ python setup.py sdist bdist_wheel
 # Setting up the local package
 cd release/one_click_windows_gui
 # Make sure you include the required extra packages and always use the stable or very-stable options!
-pip install "../../dist/alphaviz-1.1.4-py3-none-any.whl[stable,gui-stable]"
+pip install "../../dist/alphaviz-1.1.5-py3-none-any.whl[stable,gui-stable]"
 
 # Creating the stand-alone pyinstaller folder
 pip install pyinstaller==4.2


### PR DESCRIPTION
Changes in this version:

### 1.1.5
* FEAT: Enable fine-tuning of retention times for predictions.
* FEAT: Add the predicted retention time and ion mobility values to the "Main tab" of the dashboard.
* FIX: Correct the mass calculation for modified peptides in prediction mode.
* FIX: After selecting a new protein, always show the first page of the peptide table.
* STYLE: Update the AlphaViz logo.