### PR TITLE
update pyproject.toml to enable using poetry as dependency manager

### DIFF
--- a/alphaviz/gui.py
+++ b/alphaviz/gui.py
@@ -248,7 +248,7 @@ class MainWidget(object):
                 download_new_version_button,
                 align='center',
             ),
-            background='#eaeaea',
+            #background='#eaeaea',
             align='center',
             sizing_mode='stretch_width',
             height=190,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,135 @@
+[tool.poetry]
+name = "alphaviz"
+version = "1.1.8"
+description = "alphaviz"
+authors = [ "Eugenia Voytik <opensource@alphapept.com>" ]
+
+repository = "https://github.com/MannLabs/alphaviz"
+documentation = "https://github.com/Mannlabs/alphaviz"
+readme = "README.md"
+#package-mode=false
+packages = [
+  {include = "alphaviz", from="."}
+]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<3.13"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.2.0"
+pytest-cov = "^4.0.0"
+deptry = "^0.16.2"
+mypy = "^1.5.1"
+pre-commit = "^3.4.0"
+tox = "^4.11.1"
+alphatims = {path = "../alphatims", develop = true}
+panel = "1.6.1"
+plotly = "6.0.1"
+holoviews = "1.20.2"
+datashader = "0.17.0"
+beautifulsoup4 = "4.13.3"
+bokeh = ">=2.4.2"
+matplotlib = ">=3.4.3"
+pyteomics = ">=4.5"
+requests = ">=2.27.1"
+jinja2 = ">=3.0.2"
+peptdeep = "1.3.1"
+alphabase = "1.6.0"
+alpharaw = "0.4.6"
+xarray = "2025.3.0"
+multipledispatch = "1.0.0"
+
+
+
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = "^1.4.2"
+mkdocs-material = "^9.2.7"
+mkdocstrings = {extras = ["python"], version = "^0.26.1"}
+
+[tool.poetry.scripts]
+alphaviz-gui = "alphaviz.gui:run"
+
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+files = ["alphaviz"]
+disallow_untyped_defs = "True"
+disallow_any_unimported = "True"
+no_implicit_optional = "True"
+check_untyped_defs = "True"
+warn_return_any = "True"
+warn_unused_ignores = "True"
+show_error_codes = "True"
+
+
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = [
+  "."
+]
+log_cli = true
+log_cli_level = "DEBUG"
+log_cli_format = "%(message)s"
+
+
+[tool.ruff]
+target-version = "py39"
+line-length = 120
+fix = true
+select = [
+    # flake8-2020
+    "YTT",
+    # flake8-bandit
+    "S",
+    # flake8-bugbear
+    "B",
+    # flake8-builtins
+    "A",
+    # flake8-comprehensions
+    "C4",
+    # flake8-debugger
+    "T10",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # mccabe
+    "C90",
+    # pycodestyle
+    "E", "W",
+    # pyflakes
+    "F",
+    # pygrep-hooks
+    "PGH",
+    # pyupgrade
+    "UP",
+    # ruff
+    "RUF",
+    # tryceratops
+    "TRY",
+]
+ignore = [
+    # LineTooLong
+    "E501",
+    # DoNotAssignLambda
+    "E731",
+]
+
+[tool.ruff.format]
+preview = true
+
+[tool.coverage.report]
+skip_empty = true
+
+[tool.coverage.run]
+branch = true
+source = ["alphaviz"]
+
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101"]


### PR DESCRIPTION
update pyproject.toml to enable using poetry as dependency manager.  there's also a minor change to remove using the "background" parameter for the panel, as that seems to be deprecated

As alphaviz depends on alphatims, this pull request also depends on a related pull request in alphatims
https://github.com/MannLabs/alphatims/pull/297

### For a clean Python environment on Macs:
- Install Homebrew.  Follow instructions on [Homebrew](https://brew.sh/) 
- Install mono using Homebrew.  Follow instructions on [mono](https://formulae.brew.sh/formula/mono) 
- Install poetry using Homebrew. Follow instructions on [poetry](https://formulae.brew.sh/formula/poetry)

### To run this using Poetry
- clone the alphatims repo that contains the pull request
- close this repo to sit next to alphatims
- in the cloned repo, check out the branch that contains the pull request
- install dependencies using poetry, run the tests, and run the gui
`poetry update`
`poetry run pytest`
`poetry run alphaviz-gui`


